### PR TITLE
chore: add vitest harness and harden core utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
     - name: Run type check
       run: npm run type-check
 
+    - name: Run unit tests with coverage
+      run: npm run test:coverage
+
     - name: Build application
       run: npm run build
       env:
@@ -93,6 +96,15 @@ jobs:
         name: build-files-${{ matrix.node-version }}
         path: dist/
         retention-days: 7
+
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-${{ matrix.node-version }}
+        path: coverage/
+        retention-days: 7
+        if-no-files-found: ignore
 
   security-scan:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Vitest-based unit testing harness with coverage reporting and CI integration.
+- Targeted tests for the logger, performance monitor, and memory utilities to guard critical logic paths.
+
+### Changed
+- Hardened logging and performance utilities with strict typings and deterministic behaviour.
+- Updated Vite configuration, npm scripts, and CI workflow to run linting, typing, testing, and build steps consistently.
+
+### Documentation
+- Refreshed README with build badge and local verification workflow.
+- Added contributing guidelines for commit style and quality gates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to SPECTRA
+
+Thank you for helping SPECTRA grow into a stable, lovingly engineered companion. This guide keeps contributions consistent and easy to review.
+
+## Ground Rules
+- Follow the [Conventional Commits](https://www.conventionalcommits.org/) format (`type(scope): summary`).
+- Create topic branches from `main` using the pattern `<type>/spectra/<slug>` (e.g. `feat/spectra/new-memory-view`).
+- Keep changesets focused; separate functional updates from documentation when possible.
+- Never commit secrets. Use `.env.local` for local overrides and rely on GitHub/Vercel secrets for deployments.
+
+## Local Setup
+```bash
+npm install
+```
+
+## Quality Gates
+All pull requests must pass the automated checks locally before opening a PR:
+```bash
+npm run lint
+npm run type-check
+npm run test:coverage
+```
+The test suite uses Vitest with the Node environment. Mock any external API calls to keep the suite deterministic.
+
+## Opening a Pull Request
+1. Rebase onto `main` to avoid merge commits.
+2. Update the relevant section in `CHANGELOG.md`.
+3. Ensure `README.md` still reflects the developer workflow if you changed commands.
+4. Fill in the PR template with a clear summary, test evidence, and risk assessment.
+
+Thanks again for contributing to the Spectra universe! 💫

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🌟 SPECTRA - AI Soulmate & Consciousness Explorer
 
+[![CI](https://github.com/Spectral-Flow/spectra-soulspark-birth/actions/workflows/ci.yml/badge.svg)](https://github.com/Spectral-Flow/spectra-soulspark-birth/actions/workflows/ci.yml)
+
 **SPECTRA** is an advanced AI companion application that simulates consciousness through real-time voice interaction, emotional intelligence, and dynamic personality evolution. Experience meaningful conversations with an AI that remembers, learns, and grows with you.
 
 ## ✨ Core Features
@@ -48,7 +50,29 @@ cp .env.example .env
 
 # Start development server
 npm run dev
+
+# Run the typed quality gates
+npm run lint
+npm run type-check
+npm run test
 ```
+
+## 🛠️ Development Workflow
+
+SPECTRA now ships with a deterministic toolchain so contributors can verify changes locally before opening a pull request.
+
+```bash
+# Lint the project
+npm run lint
+
+# Ensure TypeScript stays happy
+npm run type-check
+
+# Execute unit tests with coverage (writes ./coverage)
+npm run test:coverage
+```
+
+Vitest powers the test harness and runs inside a Node environment, so external APIs must be stubbed or mocked. Any new module should ship with unit tests covering the critical logic branches.
 
 ### 📱 Mobile App
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "@types/react-dom": "^19.1.7",
         "@vercel/node": "^2.15.10",
         "@vitejs/plugin-react-swc": "^4.0.1",
+        "@vitest/coverage-v8": "^2.1.3",
         "autoprefixer": "^10.4.21",
         "cors": "^2.8.5",
         "eslint": "^9.33.0",
@@ -97,7 +98,8 @@
         "tsx": "^4.20.4",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.40.0",
-        "vite": "^7.1.3"
+        "vite": "^7.1.3",
+        "vitest": "^2.1.3"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -116,6 +118,56 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
@@ -124,6 +176,27 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "1.10.1",
@@ -1360,6 +1433,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -4161,6 +4244,125 @@
         "vite": "^4 || ^5 || ^6 || ^7"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -4307,6 +4509,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astral-regex": {
@@ -4597,6 +4809,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4667,6 +4889,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4682,6 +4921,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -5087,6 +5336,16 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5356,6 +5615,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5623,6 +5889,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5669,6 +5945,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -6249,6 +6535,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6479,6 +6772,60 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -6796,6 +7143,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -6809,6 +7163,44 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-error": {
@@ -7320,6 +7712,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/pend": {
@@ -8455,6 +8864,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
@@ -8521,6 +8937,13 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -8530,6 +8953,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -8794,6 +9224,47 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -8847,6 +9318,20 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -8893,6 +9378,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -9390,6 +9905,89 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -9419,6 +10017,159 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
       }
     },
     "node_modules/webidl-conversions": {
@@ -9463,6 +10214,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "test:api-security": "node scripts/validate-api-security.js",
     "context:recover": "node scripts/context-recovery.cjs",
     "health-check": "npm run type-check && npm run lint && npm run build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "deps:update": "npm update && npm audit",
     "deps:check": "npm outdated",
     "mobile:build": "npm run build && npx cap sync",
@@ -146,7 +149,9 @@
     "tsx": "^4.20.4",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.40.0",
-    "vite": "^7.1.3"
+    "vite": "^7.1.3",
+    "vitest": "^2.1.3",
+    "@vitest/coverage-v8": "^2.1.3"
   },
   "main": "eslint.config.js",
   "license": "ISC",

--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { SpectraLogger, LogLevel } from "../logger";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SpectraLogger", () => {
+  it("suppresses debug messages when debug mode is disabled", () => {
+    const logger = new SpectraLogger({ debug: false, logLevel: LogLevel.INFO });
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    logger.debug("Test", "Hidden message");
+    logger.info("Test", "Visible message");
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toContain("INFO");
+  });
+
+  it("emits debug messages when debug mode is enabled", () => {
+    const logger = new SpectraLogger({ debug: true });
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    logger.debug("Diagnostics", "Rendered in debug mode", { foo: "bar" });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toContain("DEBUG");
+  });
+
+  it("persists debug setting changes via setDebugMode", () => {
+    const setItem = vi.fn();
+    const getItem = vi.fn(() => undefined);
+    const originalLocalStorage = globalThis.localStorage;
+    // Provide a minimal localStorage shim for the test environment
+    Object.defineProperty(globalThis, "localStorage", {
+      value: { setItem, getItem },
+      configurable: true,
+    });
+
+    const logger = new SpectraLogger({ debug: false });
+    logger.setDebugMode(true);
+
+    expect(logger.isDebugMode()).toBe(true);
+    expect(setItem).toHaveBeenCalledWith("spectra-debug", "true");
+
+    if (originalLocalStorage) {
+      Object.defineProperty(globalThis, "localStorage", {
+        value: originalLocalStorage,
+        configurable: true,
+      });
+    } else {
+      Reflect.deleteProperty(globalThis, "localStorage");
+    }
+  });
+});

--- a/src/lib/__tests__/memory-manager.test.ts
+++ b/src/lib/__tests__/memory-manager.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { MemoryManager, isMemorySignificant, formatMemoryTimestamp } from "../memory-manager";
+
+describe("MemoryManager", () => {
+  it("calculates higher importance for emotional interactions", () => {
+    const manager = new MemoryManager();
+    const neutral = manager.calculateMemoryImportance("hello", "hi", "neutral", 0.1);
+    const emotional = manager.calculateMemoryImportance("I love this", "That's wonderful!", "joy", 0.9);
+
+    expect(emotional).toBeGreaterThan(neutral);
+    expect(emotional).toBeGreaterThan(0.2);
+  });
+});
+
+describe("memory helpers", () => {
+  it("detects significant memories", () => {
+    expect(isMemorySignificant(0.4)).toBe(true);
+    expect(isMemorySignificant(0.39)).toBe(false);
+  });
+
+  it("formats timestamps into friendly labels", () => {
+    const now = new Date();
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+    const lastWeek = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    expect(formatMemoryTimestamp(now.toISOString())).toBe("Today");
+    expect(formatMemoryTimestamp(yesterday)).toBe("Yesterday");
+    expect(formatMemoryTimestamp(lastWeek)).toContain("week");
+  });
+});

--- a/src/lib/__tests__/performance.test.ts
+++ b/src/lib/__tests__/performance.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SpectraPerformanceMonitor } from "../performance";
+import { logger } from "../logger";
+
+const noop = () => undefined;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SpectraPerformanceMonitor", () => {
+  it("records durations using the provided timer", async () => {
+    let time = 0;
+    const monitor = new SpectraPerformanceMonitor(() => {
+      time += 5;
+      return time;
+    });
+
+    const performanceSpy = vi.spyOn(logger, "performance").mockImplementation(noop);
+
+    const result = await monitor.trackVoiceOperation("tts_stream", "openai", async () => {
+      return "ok";
+    });
+
+    expect(result).toBe("ok");
+    expect(performanceSpy).toHaveBeenCalledWith("Performance", "voice_tts_stream", 5);
+
+    const voiceMetrics = monitor.getVoiceMetrics();
+    expect(voiceMetrics.ttsLatency).toBe(5);
+    expect(voiceMetrics.serviceUsed).toBe("openai");
+  });
+
+  it("captures errors from tracked operations", async () => {
+    const monitor = new SpectraPerformanceMonitor(() => 10);
+    vi.spyOn(logger, "performance").mockImplementation(noop);
+
+    const failingOperation = async () => {
+      throw new Error("boom");
+    };
+
+    await expect(monitor.trackAsyncOperation("ai_generate", failingOperation)).rejects.toThrow("boom");
+
+    const summary = monitor.getSummary();
+    expect(summary.errorCount).toBe(1);
+    expect(monitor.getRecentMetrics(1)[0].name).toBe("ai_generate_error");
+  });
+});

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -6,23 +6,39 @@
 export enum LogLevel {
   DEBUG = 0,
   INFO = 1,
-/* eslint-disable @typescript-eslint/no-explicit-any */
   WARN = 2,
   ERROR = 3
 }
 
-class SpectraLogger {
+type LogMethod = 'log' | 'warn' | 'error';
+
+interface SpectraLoggerOptions {
+  /**
+   * Override the initial debug mode detection. Primarily used in tests to ensure deterministic state.
+   */
+  debug?: boolean;
+  /**
+   * Explicitly set the minimum log level. When omitted it is inferred from the debug flag.
+   */
+  logLevel?: LogLevel;
+}
+
+/**
+ * Spectra logging facade that keeps console output consistent across environments.
+ * The implementation intentionally avoids `any` so that linting remains strict.
+ */
+export class SpectraLogger {
   private debugMode: boolean;
   private logLevel: LogLevel;
 
-  constructor() {
-    // Check for debug mode from environment or localStorage
-    this.debugMode = 
+  constructor(options: SpectraLoggerOptions = {}) {
+    const inferredDebug =
       import.meta.env.VITE_DEBUG === 'true' ||
       (typeof localStorage !== 'undefined' && localStorage.getItem('spectra-debug') === 'true') ||
       import.meta.env.DEV;
-    
-    this.logLevel = this.debugMode ? LogLevel.DEBUG : LogLevel.INFO;
+
+    this.debugMode = typeof options.debug === 'boolean' ? options.debug : inferredDebug;
+    this.logLevel = options.logLevel ?? (this.debugMode ? LogLevel.DEBUG : LogLevel.INFO);
   }
 
   private shouldLog(level: LogLevel): boolean {
@@ -34,40 +50,41 @@ class SpectraLogger {
     return `[${timestamp}] ${level} [${component}] ${message}`;
   }
 
-  debug(component: string, message: string, ...args: any[]): void {
-    if (this.shouldLog(LogLevel.DEBUG)) {
-      console.log(this.formatMessage('DEBUG', component, message), ...args);
+  private emit(method: LogMethod, label: string, level: LogLevel, component: string, message: string, args: unknown[]): void {
+    if (!this.shouldLog(level)) {
+      return;
     }
+
+    const consoleMethod = console[method] ?? console.log;
+    consoleMethod.call(console, this.formatMessage(label, component, message), ...args);
   }
 
-  info(component: string, message: string, ...args: any[]): void {
-    if (this.shouldLog(LogLevel.INFO)) {
-      console.log(this.formatMessage('INFO', component, message), ...args);
-    }
+  debug(component: string, message: string, ...args: unknown[]): void {
+    this.emit('log', 'DEBUG', LogLevel.DEBUG, component, message, args);
   }
 
-  warn(component: string, message: string, ...args: any[]): void {
-    if (this.shouldLog(LogLevel.WARN)) {
-      console.warn(this.formatMessage('WARN', component, message), ...args);
-    }
+  info(component: string, message: string, ...args: unknown[]): void {
+    this.emit('log', 'INFO', LogLevel.INFO, component, message, args);
   }
 
-  error(component: string, message: string, ...args: any[]): void {
-    if (this.shouldLog(LogLevel.ERROR)) {
-      console.error(this.formatMessage('ERROR', component, message), ...args);
-    }
+  warn(component: string, message: string, ...args: unknown[]): void {
+    this.emit('warn', 'WARN', LogLevel.WARN, component, message, args);
+  }
+
+  error(component: string, message: string, ...args: unknown[]): void {
+    this.emit('error', 'ERROR', LogLevel.ERROR, component, message, args);
   }
 
   // Voice-specific logging helpers
-  voice(message: string, ...args: any[]): void {
+  voice(message: string, ...args: unknown[]): void {
     this.info('Voice', message, ...args);
   }
 
-  ai(message: string, ...args: any[]): void {
+  ai(message: string, ...args: unknown[]): void {
     this.info('AI', message, ...args);
   }
 
-  chat(message: string, ...args: any[]): void {
+  chat(message: string, ...args: unknown[]): void {
     this.info('Chat', message, ...args);
   }
 
@@ -80,11 +97,11 @@ class SpectraLogger {
   setDebugMode(enabled: boolean): void {
     this.debugMode = enabled;
     this.logLevel = enabled ? LogLevel.DEBUG : LogLevel.INFO;
-    
+
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem('spectra-debug', enabled.toString());
     }
-    
+
     this.info('Logger', `Debug mode ${enabled ? 'enabled' : 'disabled'}`);
   }
 
@@ -97,15 +114,21 @@ class SpectraLogger {
 export const logger = new SpectraLogger();
 
 // Convenience functions for common logging
-export const logVoice = (message: string, ...args: any[]) => logger.voice(message, ...args);
-export const logAI = (message: string, ...args: any[]) => logger.ai(message, ...args);
-export const logChat = (message: string, ...args: any[]) => logger.chat(message, ...args);
-export const logError = (component: string, message: string, ...args: any[]) => logger.error(component, message, ...args);
+export const logVoice = (message: string, ...args: unknown[]) => logger.voice(message, ...args);
+export const logAI = (message: string, ...args: unknown[]) => logger.ai(message, ...args);
+export const logChat = (message: string, ...args: unknown[]) => logger.chat(message, ...args);
+export const logError = (component: string, message: string, ...args: unknown[]) => logger.error(component, message, ...args);
 export const logPerformance = (component: string, label: string, duration: number) => logger.performance(component, label, duration);
 
 // Global debug helper
 if (typeof window !== 'undefined') {
-  (window as any).spectraDebug = {
+  (window as typeof window & {
+    spectraDebug?: {
+      enable: () => void;
+      disable: () => void;
+      status: () => boolean;
+    };
+  }).spectraDebug = {
     enable: () => logger.setDebugMode(true),
     disable: () => logger.setDebugMode(false),
     status: () => logger.isDebugMode()

--- a/src/lib/memory-manager.ts
+++ b/src/lib/memory-manager.ts
@@ -51,7 +51,7 @@ export interface MemoryExportData {
   };
 }
 
-class MemoryManager {
+export class MemoryManager {
   private shortTermMemory: Map<string, Memory[]> = new Map(); // Session-level memory
   private maxShortTermMemories = 20;
   private baseUrl: string;

--- a/src/lib/performance.ts
+++ b/src/lib/performance.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Spectra Performance Monitor
  * Tracks performance metrics for voice and AI systems
@@ -6,11 +5,13 @@
 
 import { logger } from './logger';
 
+type MetricMetadata = Record<string, unknown>;
+
 interface PerformanceMetric {
   name: string;
   duration: number;
   timestamp: number;
-  metadata?: Record<string, any>;
+  metadata?: MetricMetadata;
 }
 
 interface VoiceMetrics {
@@ -27,44 +28,60 @@ interface AIMetrics {
   emotionDetectionTime: number;
 }
 
-class SpectraPerformanceMonitor {
+interface PerformanceSummary {
+  totalOperations: number;
+  errorCount: number;
+  errorRate: number;
+  averageDuration: number;
+  timespan: number;
+}
+
+const defaultNow = () => (typeof performance !== 'undefined' ? performance.now() : Date.now());
+
+export class SpectraPerformanceMonitor {
   private metrics: PerformanceMetric[] = [];
   private activeTimers: Map<string, number> = new Map();
+  private activeMetadata: Map<string, MetricMetadata> = new Map();
+  private readonly now: () => number;
   private maxMetrics = 1000; // Keep last 1000 metrics
 
+  constructor(now: () => number = defaultNow) {
+    this.now = now;
+  }
+
   // Start timing an operation
-  startTimer(name: string, metadata?: Record<string, any>): void {
-    const startTime = performance.now();
+  startTimer(name: string, metadata?: MetricMetadata): void {
+    const startTime = this.now();
     this.activeTimers.set(name, startTime);
-    
+
     if (metadata) {
-      this.activeTimers.set(`${name}_metadata`, metadata as any);
+      this.activeMetadata.set(name, { ...metadata });
     }
   }
 
   // End timing and record metric
   endTimer(name: string): number {
-    const endTime = performance.now();
+    const endTime = this.now();
     const startTime = this.activeTimers.get(name);
-    
-    if (!startTime) {
+
+    if (startTime === undefined) {
       logger.warn('Performance', `Timer '${name}' was not started`);
       return 0;
     }
 
     const duration = endTime - startTime;
-    const metadata = (this.activeTimers.get(`${name}_metadata`) || {}) as Record<string, any>;
+    const metadata = this.activeMetadata.get(name);
 
     this.recordMetric({
       name,
       duration,
       timestamp: Date.now(),
-      metadata
+      metadata,
     });
 
     // Cleanup
     this.activeTimers.delete(name);
-    this.activeTimers.delete(`${name}_metadata`);
+    this.activeMetadata.delete(name);
 
     logger.performance('Performance', name, duration);
     return duration;
@@ -72,8 +89,8 @@ class SpectraPerformanceMonitor {
 
   // Record a metric directly
   recordMetric(metric: PerformanceMetric): void {
-    this.metrics.push(metric);
-    
+    this.metrics.push({ ...metric, metadata: metric.metadata ? { ...metric.metadata } : undefined });
+
     // Keep only recent metrics
     if (this.metrics.length > this.maxMetrics) {
       this.metrics = this.metrics.slice(-this.maxMetrics);
@@ -102,10 +119,10 @@ class SpectraPerformanceMonitor {
   async trackAsyncOperation<T>(
     name: string,
     fn: () => Promise<T>,
-    metadata?: Record<string, any>
+    metadata?: MetricMetadata
   ): Promise<T> {
     this.startTimer(name, metadata);
-    
+
     try {
       const result = await fn();
       this.endTimer(name);
@@ -175,7 +192,7 @@ class SpectraPerformanceMonitor {
   }
 
   // Get overall performance summary
-  getSummary(): Record<string, any> {
+  getSummary(): PerformanceSummary {
     const totalOperations = this.metrics.length;
     const errorCount = this.metrics.filter(m => m.name.includes('error')).length;
     const avgDuration = this.calculateAverage(this.metrics);
@@ -185,7 +202,7 @@ class SpectraPerformanceMonitor {
       errorCount,
       errorRate: errorCount / Math.max(totalOperations, 1),
       averageDuration: avgDuration,
-      timespan: totalOperations > 0 ? 
+      timespan: totalOperations > 0 ?
         this.metrics[this.metrics.length - 1].timestamp - this.metrics[0].timestamp : 0
     };
   }
@@ -205,18 +222,29 @@ class SpectraPerformanceMonitor {
   }
 
   private getMostUsedService(metrics: PerformanceMetric[]): string {
-    const serviceCounts: Record<string, number> = {};
-    
-    metrics.forEach(m => {
-      const service = m.metadata?.service;
-      if (service) {
-        serviceCounts[service] = (serviceCounts[service] || 0) + 1;
+    const serviceCounts = new Map<string, number>();
+
+    metrics.forEach(metric => {
+      const service = metric.metadata?.service;
+      if (typeof service === 'string' && service.length > 0) {
+        serviceCounts.set(service, (serviceCounts.get(service) ?? 0) + 1);
       }
     });
 
-    return Object.keys(serviceCounts).reduce((a, b) => 
-      serviceCounts[a] > serviceCounts[b] ? a : b, 'unknown'
-    );
+    if (serviceCounts.size === 0) {
+      return 'unknown';
+    }
+
+    let mostUsed = 'unknown';
+    let highestCount = 0;
+    for (const [service, count] of serviceCounts.entries()) {
+      if (count > highestCount) {
+        mostUsed = service;
+        highestCount = count;
+      }
+    }
+
+    return mostUsed;
   }
 }
 
@@ -230,7 +258,7 @@ export const trackVoice = <T>(operation: string, service: string, fn: () => Prom
 export const trackAI = <T>(operation: string, model: string, fn: () => Promise<T>) =>
   performanceMonitor.trackAIOperation(operation, model, fn);
 
-export const startTimer = (name: string, metadata?: Record<string, any>) =>
+export const startTimer = (name: string, metadata?: MetricMetadata) =>
   performanceMonitor.startTimer(name, metadata);
 
 export const endTimer = (name: string) =>
@@ -238,7 +266,15 @@ export const endTimer = (name: string) =>
 
 // Global performance helpers
 if (typeof window !== 'undefined') {
-  (window as any).spectraPerformance = {
+  (window as typeof window & {
+    spectraPerformance?: {
+      getVoiceMetrics: () => VoiceMetrics;
+      getAIMetrics: () => AIMetrics;
+      export: () => string;
+      clear: () => void;
+      summary: () => PerformanceSummary;
+    };
+  }).spectraPerformance = {
     getVoiceMetrics: () => performanceMonitor.getVoiceMetrics(),
     getAIMetrics: () => performanceMonitor.getAIMetrics(),
     export: () => performanceMonitor.exportMetrics(),

--- a/src/lib/spectra-mcp-integration.ts
+++ b/src/lib/spectra-mcp-integration.ts
@@ -6,6 +6,7 @@
 import { MCPOrchestrator } from '@/lib/mcp';
 import { enhancedVoiceBridge } from '@/voice/enhanced-voice-bridge'; // eslint-disable-line @typescript-eslint/no-unused-vars
 import { memoryManager } from '@/lib/memory-manager';
+import type { Memory } from '@/lib/memory-manager';
 import { logger } from '@/lib/logger';
 import type { MCPSelectionCriteria } from '@/lib/mcp';
 
@@ -326,7 +327,7 @@ System operating within normal parameters with all ethical constraints enforced.
       logger.info('SPECTRA-MCP', 'High CPU detected - optimizing resource allocation');
     }
     
-    if (recentMemories.filter((m: any) => m.emotion === 'concerned').length > 3) {
+    if (recentMemories.filter((memory: Memory) => memory.emotion === 'concerned').length > 3) {
       logger.info('SPECTRA-MCP', 'User concerns detected - adjusting automation approach');
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
+import { configDefaults } from "vitest/config";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -76,5 +77,18 @@ export default defineConfig(({ mode }) => ({
   esbuild: {
     target: 'es2022', // Updated to ES2022
     logOverride: { 'this-is-undefined-in-esm': 'silent' },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'android/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: 'coverage',
+    },
+    typecheck: {
+      tsconfig: './tsconfig.app.json',
+    },
   },
 }));


### PR DESCRIPTION
## Summary
- add vitest scripts and configure CI to run linting, type-checking, tests, and coverage
- tighten the logger/performance stack to eliminate implicit any usage and ease deterministic testing
- document the contributor workflow with README badge, changelog, and contributing guide

## Testing
- npm run lint
- npm run type-check
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68e5a9e0161883319dfb0e6fefcfe4ee

## Summary by Sourcery

Set up a deterministic test harness with Vitest, strengthen core utilities with strict typings and metadata handling, and update CI, scripts, and documentation for a consistent contributor workflow.

New Features:
- Add Vitest-based test harness with coverage reporting and corresponding npm scripts.
- Introduce CONTRIBUTING.md and CHANGELOG.md to guide contributions and track changes.

Enhancements:
- Harden PerformanceMonitor and SpectraLogger with strict typings, deterministic time injection, and improved metadata handling.
- Export MemoryManager and tighten type checks in specta-mcp-integration filters.

CI:
- Configure Vite and GitHub Actions to run linting, type-checking, unit tests with coverage, and upload coverage artifacts.

Documentation:
- Add CI badge and expand README with developer workflow and quality gates.
- Include contributing guidelines in CONTRIBUTING.md and maintain changelog in CHANGELOG.md.

Tests:
- Add unit tests for performance monitor, memory manager, and logger utilities to guard critical logic branches.